### PR TITLE
Problème d'adresse de l'iframe

### DIFF
--- a/iframe.js
+++ b/iframe.js
@@ -6,11 +6,7 @@ const script = document.getElementById('ecolab-transport'),
 	tmp = document.createElement('a')
 
 tmp.href = script.src
-const baseUrl =
-		location.hostname === 'localhost'
-			? 'http://localhost:8080/'
-			: 'https://' + tmp.hostname,
-	src = `${baseUrl}?distanceInitiale=${distanceInitiale}&iframe&integratorUrl=${integratorUrl}`
+const src = `https://${tmp.hostname}?distanceInitiale=${distanceInitiale}&iframe&integratorUrl=${integratorUrl}`
 
 const iframe = document.createElement('iframe')
 


### PR DESCRIPTION
Quand on tente d'intégrer l'iframe sur un site qu'on est en train de développer par exemple sur localhost:3000, ce bout de code pensait qu'on était en train de développer ecolab-transport lui-même, et chargait donc une version locale inexistante @localhost:8080.

Fixes #39