### PR TITLE
Suggestions horizontales seulement pour les écrans tactiles

### DIFF
--- a/Suggestions.js
+++ b/Suggestions.js
@@ -16,7 +16,7 @@ export default ({ distance, setDistance }) => (
 				padding: 0.6rem;
 				margin: 0rem;
 			}
-			@media (pointer: coarse) and (max-width: 600px) {
+			@media (pointer: coarse) {
 				ul {
 					line-height: 2rem;
 					display: block;
@@ -24,6 +24,7 @@ export default ({ distance, setDistance }) => (
 					overflow-x: auto;
 					width: 90vw;
 					margin: 0 auto;
+					text-align: center;
 				}
 			}
 			li {


### PR DESCRIPTION
Suite à https://github.com/betagouv/ecolab-transport/pull/65#issuecomment-616446097

Limiter la sélection aux écrans < 600px me semble être dangereux pour
les téléphones haut de gamme qui ont une définition super élevée (écran
rétina).

Cela pose problème sur ma Surface Pro, en mode ordinateur (souris connectée) elle ne devrait réagir qu'avec ""any-pointer: coarse" mais réagit avec "pointer: coarse", il semble y avoir un bug. Les écrans d'ordinateur tactiles restents une niche donc j'en reste là pour l'instant