### PR TITLE
Limitation de la barre du graphique

### DIFF
--- a/Avion.js
+++ b/Avion.js
@@ -20,7 +20,7 @@ export default ({
 				onClick={() => setDetails(mode)}
 				css={`
 				${barStyle}
-					width: ${((distance * facteurSur) / empreinteMaximum) * 100 * 0.9}%;
+					width: ${((distance * facteurSur) / empreinteMaximum) * 100 * 0.8}%;
 					margin-right: 2px;
 					border-top-right-radius: 0;
 					border-bottom-right-radius: 0;
@@ -31,7 +31,7 @@ export default ({
 				onClick={() => setDetails(mode)}
 				css={`
 				${barStyle}
-					width: ${((distance * diff) / empreinteMaximum) * 100 * 0.9}%;
+					width: ${((distance * diff) / empreinteMaximum) * 100 * 0.8}%;
 					background:   linear-gradient(to right, purple, #a665a67a); 
 					/* The gradient represents the incertainty of this measure. We attribute a diluted purple to the end of the bar since it represents the most probable value. The most extreme but plausible value, not painted here, would be pure white.
 					 */

--- a/Classement.js
+++ b/Classement.js
@@ -73,7 +73,7 @@ export default ({
 				height: 100%;
 				left: 0;
 				z-index: -1;
-				left: ${((transportClimateBudget * 1000) / empreinteMaximum) * 100 * 0.9}%;
+				left: ${((transportClimateBudget * 1000) / empreinteMaximum) * 100 * 0.8}%;
 
 				width: 0px;
 				border-right: 8px dotted yellow;

--- a/Mode.js
+++ b/Mode.js
@@ -91,7 +91,7 @@ export default ({
 					width: ${
 						((distance * facteur(distance, mode, options)) / empreinteMaximum) *
 						100 *
-						0.9
+						0.8
 					}%;
 					${shadowStyle}
 				`}


### PR DESCRIPTION
On laissait 10% de la largeur au reste de la ligne.
Ainsi deux barres larges ne pouvaient plus se distinguer, malgré leur
valeurs différentes.
Avec 20%, le graphique est moins lisible mais on n'a plus cette erreur
en bas pour les barres importantes.

Sinon il faudrait faire des calculs de taille en JS pour vraiment optimiser les deux contraintes...
Fixes #27