### PR TITLE
Revert "Précisions phases considérées"

### DIFF
--- a/Classement.js
+++ b/Classement.js
@@ -132,7 +132,7 @@ export default ({
 					display: block;
 				`}
 			>
-				<p>Équivalent CO₂ par personne en France, phases de fonctionnement des moyens de transport et phase amont liée à la production des sources d’énergie (raffinage, transport, distribution...).</p>
+				<p>Équivalent CO₂ par personne en France, phase d'usage uniquement.</p>
 				<p>Sources : cliquer sur les différents modes.</p>
 			</small>
 			{showBudget && (


### PR DESCRIPTION
Reverts betagouv/ecolab-transport#97

On a mergé un peu vite, la nouvelle phrase n'était que dans le commentaire, et elle augmente la largeur de la page de façon non intentionnelle.